### PR TITLE
Add properties for date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Property              | JSONKey Type           | Default value
 `cgFloatValue`        | `CGFloat`              | `0.0`
 `bool`                | `Bool?`                |
 `boolValue`           | `Bool`                 | `false`
+`nsDate`              | `NSDate?`              |
 `nsURL`               | `NSURL?`               |
 `dictionary`          | `[String: AnyObject]?` |
 `dictionaryValue`     | `[String: AnyObject]`  | `[:]`
@@ -224,6 +225,8 @@ Property              | JSONKey Type           | Default value
 `jsonArrayValue`      | `[JSON]`               | `[]`
 `nsArray`             | `NSArray?`             |
 `nsArrayValue`        | `NSArray`              | `NSArray()`
+
+> Configure JSON.dateFormatter if needed for `nsDate` parsing
 
 ## Installation
 

--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -25,6 +25,9 @@
 // MARK: - Initializers
 
 public struct JSON {
+    /// The date formatter used for date conversions
+    public static var dateFormatter = NSDateFormatter()
+    
     /// The object on which any subsequent method operates
     public let object: AnyObject?
 

--- a/Source/JSONKey.swift
+++ b/Source/JSONKey.swift
@@ -266,6 +266,21 @@ extension JSON {
     }
 }
 
+// MARK: - NSDate
+
+extension JSON {
+    /**
+     Returns the value associated with the given key as a NSDate or nil if not present/convertible.
+     
+     - parameter key: The key.
+     
+     - returns: The value associated with the given key as a NSDate or nil if not present/convertible.
+     */
+    public subscript(key: JSONKey<NSDate?>) -> NSDate? {
+        return self[key.type].nsDate
+    }
+}
+
 // MARK: - NSURL
 
 extension JSON {

--- a/Source/Properties.swift
+++ b/Source/Properties.swift
@@ -80,6 +80,13 @@ extension JSON {
     public var boolValue: Bool { return bool ?? false }
 }
 
+// MARK: - NSDate
+
+extension JSON {
+    /// The value as a NSDate or nil if not present/convertible
+    public var nsDate: NSDate? { return JSON.dateFormatter.dateFromString(stringValue) }
+}
+
 // MARK: - NSURL
 
 extension JSON {

--- a/Tests/JSONKeyTests.swift
+++ b/Tests/JSONKeyTests.swift
@@ -49,6 +49,7 @@ extension JSONKeys {
     static let dictionaryJSON = JSONKey<[String: JSON]>("dictionaryJSON")
     static let optional_dictionaryJSON = JSONKey<[String: JSON]?>("optional_dictionaryJSON")
     static let json = JSONKey<JSON>("json")
+    static let date = JSONKey<NSDate?>("date")
 }
 
 class JSONKeyTests: XCTestCase {
@@ -68,6 +69,7 @@ class JSONKeyTests: XCTestCase {
             "optional_array": ["string", 42, 4.2, true],
             "dictionary": ["string": 42],
             "optional_dictionary": ["string": 42],
+            "date": "2016-04-12T13:29:32"
         ]
         
         XCTAssertEqual("string", json[.string])
@@ -86,6 +88,12 @@ class JSONKeyTests: XCTestCase {
         AssertEqualArrays(["string", 42, 4.2, true], json[.optional_array]!)
         AssertEqualDictionaries(["string": 42], json[.dictionary])
         AssertEqualDictionaries(["string": 42], json[.optional_dictionary])
+        
+        JSON.dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        XCTAssertEqual(formatter.dateFromString("2016-04-12T13:29:32"), json[.date])
     }
     
     func testPath() {

--- a/Tests/PropertiesTests.swift
+++ b/Tests/PropertiesTests.swift
@@ -223,5 +223,34 @@ class PropertiesTests: XCTestCase {
         XCTAssert(json["name"].jsonArray == nil)
         XCTAssert(json["name"].jsonArrayValue.isEmpty)
     }
+    
+    func testDate() {
+        let formatter = NSDateFormatter()
+        let json: JSON = [
+            "date1": "2016-04-12T13:29:32",
+            "date2": "16/04/2016",
+            "date3": "05/11/2012",
+            "date4": "April 10, 2020",
+            "invaliddate": "abc123"
+        ]
+        
+        // Value is present and convertible
+        
+        JSON.dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        XCTAssertEqual(formatter.dateFromString("2016-04-12T13:29:32"), json["date1"].nsDate)
+        
+        JSON.dateFormatter.dateFormat = "dd-MM-yyyy"
+        formatter.dateFormat = "dd-MM-yyyy"
+        XCTAssertEqual(formatter.dateFromString("16/04/2016"), json["date2"].nsDate)
+        XCTAssertEqual(formatter.dateFromString("05/11/2012"), json["date3"].nsDate)
+        
+        JSON.dateFormatter.dateFormat = "MMMM dd, yyyy"
+        formatter.dateFormat = "MMMM dd, yyyy"
+        XCTAssertEqual(formatter.dateFromString("April 10, 2020"), json["date4"].nsDate)
+        
+        // Value is not present
+        XCTAssertNil(json["invaliddate"].nsDate)
+    }
 
 }


### PR DESCRIPTION
Properties and functions added for parsing dates with unit tests.

For flexibility, you can let `JASON` parse the date using a default ISO date formatting string (`yyyy-MM-dd'T'HH:mm:ss`), or pass in a string format or `NSDateFormatter`:

```
let json: JSON = [
    "date1": "2016-04-12T13:29:32",
    "date2": "16/04/2016",
    "date3": "April 10, 2020"
]

json["date1"].dateValue
json["date2"].dateValue("dd-MM-yyyy")

let formatter = NSDateFormatter()
formatter.dateFormat = "MMMM dd, yyyy"

json["date3"].dateValue(formatter)
```

This is related to discussion #15.
