### PR TITLE
nsURL now returns nil when string is not present. Added test for nsUrl

### DIFF
--- a/Source/Properties.swift
+++ b/Source/Properties.swift
@@ -91,7 +91,12 @@ extension JSON {
 
 extension JSON {
     /// The value as an instance of NSURL or nil if not convertible
-    public var nsURL: NSURL? { return NSURL(string: stringValue) }
+    public var nsURL: NSURL? {
+        if let encodedString = string?.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()) {
+            return NSURL(string: encodedString)
+        }
+        return nil
+    }
 }
 
 // MARK: - Dictionary

--- a/Tests/PropertiesTests.swift
+++ b/Tests/PropertiesTests.swift
@@ -252,5 +252,25 @@ class PropertiesTests: XCTestCase {
         // Value is not present
         XCTAssertNil(json["invaliddate"].nsDate)
     }
+    
+    func testUrl() {
+        let json: JSON = [
+            "valid": "https://github.com/delba/JASON",
+            "invalid": "http://example.com/file[/].html",
+            "empty": NSNull()
+        ]
+        
+        // Value is present and convertible
+        XCTAssertNotNil(json["valid"].nsURL)
+        XCTAssertNotNil(json["invalid"].nsURL) // Invalid url should be encoded
+        
+        // Value is present but not convertible
+        XCTAssertNil(json["empty"].nsURL)
+        
+        // Value is not present
+        XCTAssertNil(json["unkown"].nsURL)
+        
+        
+    }
 
 }


### PR DESCRIPTION
nsURL always returned an NSURL even when the json property was empty or null. This made it impossible to check for optionals when using nsURL. This pull request fixes that and add a unit test for nsURL.
