### PR TITLE
Update for Xcode 8 beta 6. convert to Swift 3

### DIFF
--- a/Source/JSONKey.swift
+++ b/Source/JSONKey.swift
@@ -30,11 +30,11 @@ private enum KeyType {
     case path([Any])
 }
 
-public class JSONKeys {
+open class JSONKeys {
     fileprivate init() {}
 }
 
-public class JSONKey<ValueType>: JSONKeys {
+open class JSONKey<ValueType>: JSONKeys {
     fileprivate let type: KeyType
     
     /**


### PR DESCRIPTION
After installation into cocoapods, an error occurs. 
convert to Swift 3 in Xcode 8 beta 6.
