### PR TITLE
Add NSDictionary-to-JSON conversion benchmark.

### DIFF
--- a/BenchmarksTests/BenchmarksTests.swift
+++ b/BenchmarksTests/BenchmarksTests.swift
@@ -78,4 +78,31 @@ class BenchmarksTests: XCTestCase {
         }
     }
     
+    func makeNSDict(ofSize: Int) -> NSDictionary {
+        let dict = NSMutableDictionary()
+        for i in 0..<ofSize {
+            dict.setValue("foo I am a random string yes indeed I am \(i)", forKey: "foo \(i)")
+        }
+        return dict
+    }
+    
+    func testJASONConvertNSDict_10000() {
+        let dict = makeNSDict(ofSize: 10_000)
+        
+        measure {
+            let json = JASON.JSON(dict)
+            let val = json["foo 2"]
+            assert(val.string!.hasPrefix("foo"))
+        }
+    }
+    
+    func testSwiftyJSONConvertNSDict_10000() {
+        let dict = makeNSDict(ofSize: 10_000)
+        
+        measure {
+            let json = SwiftyJSON.JSON(dict)
+            let val = json["foo 2"]
+            assert(val.string!.hasPrefix("foo"))
+        }
+    }
 }


### PR DESCRIPTION
An ideal JSON library will maintain data as an NSDictionary internally rather
than force a conversion to a Swift dictionary during init.

On iPhone 5C, JASON runs in 0.002 sec, SwiftyJSON runs in 0.030 sec on a 10,000 item NSDictionary.

JSON data typically originates as an NSDictionary, and converting
a large NSDictionary to a Swift dictionary is slow (due to mem copy and casting of
every item in the dict).

Type conversions to Swift native types should happen only on key access, thus
amortizing the cost (or avoiding the bulk conversion cost in the case where
there is no consecutive loop access of every key in the JSON data).