### PR TITLE
Fix compile error on linux

### DIFF
--- a/Source/JSONKey.swift
+++ b/Source/JSONKey.swift
@@ -23,7 +23,9 @@
 //
 
 import Foundation
+#if !os(Linux)
 import CoreGraphics
+#endif
 
 // MARK: - JSONKey
 
@@ -220,6 +222,7 @@ extension JSON {
         return self[key.type].nsNumberValue
     }
 
+    #if !os(Linux)
     /**
      Returns the value associated with the given key as a CGFloat or nil if not present/convertible.
      
@@ -241,6 +244,7 @@ extension JSON {
     public subscript(key: JSONKey<CGFloat>) -> CGFloat {
         return self[key.type].cgFloatValue
     }
+    #endif
 }
 
 // MARK: - Bool

--- a/Source/Properties.swift
+++ b/Source/Properties.swift
@@ -23,7 +23,9 @@
 //
 
 import Foundation
+#if !os(Linux)
 import CoreGraphics
+#endif
 
 // MARK: - JSON
 
@@ -68,10 +70,12 @@ extension JSON {
     /// The value as a NSNumber or 0 if not present/convertible
     public var nsNumberValue: NSNumber { return nsNumber ?? 0 }
 
+    #if !os(Linux)
     /// The value as a CGFloat or nil if not present/convertible
     public var cgFloat: CGFloat? { return nsNumber != nil ? CGFloat(truncating: nsNumber!) : nil }
     /// The value as a CGFloat or 0.0 if not present/convertible
     public var cgFloatValue: CGFloat { return cgFloat ?? 0 }
+    #endif
 }
 
 // MARK: - Bool

--- a/Source/Supporting Files/JASON.h
+++ b/Source/Supporting Files/JASON.h
@@ -23,7 +23,9 @@
 //
 
 @import Foundation;
+#if !TARGET_OS_LINUX
 @import CoreGraphics.CGBase;
+#endif
 
 FOUNDATION_EXPORT double JASONVersionNumber;
 FOUNDATION_EXPORT const unsigned char JASONVersionString[];


### PR DESCRIPTION
I got the following error on linux.
```shell
.build/checkouts/JASON/Source/JSONKey.swift:26:8 error: No such module 'CoreGraphics'
import CoreGraphics
       ^
```
So I remove CoreGraphics dependency for linux.
